### PR TITLE
feat: add replay button

### DIFF
--- a/EnhancedMediaPlayer/MediaPlayerControllerRepresentable.swift
+++ b/EnhancedMediaPlayer/MediaPlayerControllerRepresentable.swift
@@ -34,6 +34,11 @@ public struct MediaPlayerControllerRepresentable: UIViewControllerRepresentable 
         playerManager.playerController.player?.pause()
     }
 
+    func replay() {
+        playerManager.playerController.player?.seek(to: CMTime.zero)
+        playerManager.playerController.player?.play()
+    }
+
     func observePlayToEnd(onEnd action: @escaping () -> Void) {
         NotificationCenter.default.addObserver(
             forName: NSNotification.Name.AVPlayerItemDidPlayToEndTime,

--- a/EnhancedMediaPlayer/MediaPlayerView.swift
+++ b/EnhancedMediaPlayer/MediaPlayerView.swift
@@ -35,11 +35,11 @@ struct MediaPlayerView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    @ViewBuilder private func renderActionButtons() -> some View {
+    @ViewBuilder private func renderActionButtons() -> some View {        
         ZStack {
             VStack {
                 HStack {
-                    // TODO: implment ActionButtons top row
+                    renderLoop()
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 HStack {
@@ -47,7 +47,7 @@ struct MediaPlayerView: View {
                     Spacer()
                     renderPlayPauseReplay()
                     Spacer()
-                    renderForward()
+                    renderForward(disabled: (viewModel.playerState == .finished))
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 HStack {
@@ -63,6 +63,15 @@ struct MediaPlayerView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
         }
+    }
+
+    @ViewBuilder private func renderPlayPause() -> some View {
+        renderButton(control: viewModel.playerState == .playing ? .pause : .play)
+    }
+
+    @ViewBuilder private func renderLoop() -> some View {
+        renderButton(control: .loop, color: viewModel.inLoop ? .blue : .white)
+            .frame(maxWidth: .infinity, alignment: .trailing)
     }
     
     @ViewBuilder private func renderPlayPauseReplay() -> some View {
@@ -80,23 +89,23 @@ struct MediaPlayerView: View {
         }
     }
     
-    @ViewBuilder private func renderForward() -> some View {
+    @ViewBuilder private func renderForward(disabled: Bool) -> some View {
         renderTimeElapsedWrapper {
-            renderButton(control: .forward)
+            renderButton(control: .forward, disabled: disabled)
         }
     }
-    
+
     @ViewBuilder private func renderSettings() -> some View {
         renderButton(control: .settings)
     }
-
-    @ViewBuilder private func renderButton(control: Control) -> some View {
+    
+    @ViewBuilder private func renderButton(control: Control, disabled: Bool = false, color: Color = .white) -> some View {
         Button(action: { viewModel.onTapAction?(control) }) {
             control.systemImage
-                .resizable()
-                .frame(width: Constants.iconSize.width, height: Constants.iconSize.height)
-                .foregroundColor(.white)
+                .font(.system(size: Constants.iconSize))
+                .tint(color)
         }
+        .disabled(disabled)
     }
     
     @ViewBuilder private func renderTimeElapsedWrapper<Content: View>(
@@ -114,6 +123,7 @@ struct MediaPlayerView: View {
 extension MediaPlayerView {
     class ViewModel: ObservableObject {
         @Published var playerState: PlayerState = .loading
+        @Published var inLoop: Bool = false
         @Published var showSettingsMenu = false
         @Published var shouldRenderOverlay = false
         
@@ -134,7 +144,7 @@ extension MediaPlayerView {
 extension MediaPlayerView {
     enum Constants {
         static let timeFontSize: CGFloat = 12
-        static let iconSize: CGSize = .init(width: 30, height: 30)
+        static let iconSize: CGFloat = 40.0
         static let paddingWidthDivider: CGFloat = 6
         static let overlayOpacity: CGFloat = 0.3
         static let settingsIconPadding: CGFloat = 8.0
@@ -155,6 +165,7 @@ extension MediaPlayerView {
     enum Control {
         case play
         case pause
+        case loop
         case replay
         case rewind
         case forward
@@ -166,6 +177,8 @@ extension MediaPlayerView {
                 return Image(systemName: Constants.playIcon)
             case .pause:
                 return Image(systemName: Constants.pauseIcon)
+            case .loop:
+                return Image(systemName: Constants.loopIcon)
             case .replay:
                 return Image(systemName: Constants.replayIcon)
             case .rewind:
@@ -183,6 +196,7 @@ extension MediaPlayerView.Control {
     enum Constants {
         static let playIcon = "play.fill"
         static let pauseIcon = "pause.fill"
+        static let loopIcon = "infinity"
         static let replayIcon = "repeat"
         static let forwardIcon = "goforward"
         static let rewindIcon = "gobackward"

--- a/EnhancedMediaPlayer/MediaPlayerViewController.swift
+++ b/EnhancedMediaPlayer/MediaPlayerViewController.swift
@@ -35,6 +35,7 @@ class MediaPlayerViewController: UIHostingController<MediaPlayerView> {
             switch control {
                 case .play: self.play()
                 case .pause: self.pause()
+                case .loop: self.loop()
                 case .replay: self.replay()
                 case .rewind: self.rewind()
                 case .forward: self.forward()
@@ -45,7 +46,11 @@ class MediaPlayerViewController: UIHostingController<MediaPlayerView> {
     
     private func observePlayToEnd() {
         self.playerViewHandler.observePlayToEnd {
-            self.viewModel.playerState = .finished
+            if self.viewModel.inLoop {
+                self.replay()
+            } else {
+                self.viewModel.playerState = .finished
+            }
         }
     }
     
@@ -62,9 +67,14 @@ class MediaPlayerViewController: UIHostingController<MediaPlayerView> {
         self.viewModel.playerState = .paused
         self.playerViewHandler.pause()
     }
+
+    private func loop() {
+        self.viewModel.inLoop.toggle()
+    }
     
     private func replay() {
-        // TODO: implement replay
+        self.viewModel.playerState = .playing
+        self.playerViewHandler.replay()
     }
     
     private func rewind() {


### PR DESCRIPTION
## Description

add functional replay button and loop button

## Related Issues

- Closes [#676](https://github.com/profusion/quickstart-ios-graphql/issues/676)

## Progress

- [x] Be able to replay a video
- [x] Be able to replay an audio
- [x] Forward controls must be disabled at the end of the video
- [x] (Nice to have) Auto replay (loop)

<!-- Also, don't forget to review your code before marking it as ready to merge -->


## How to test it

### Replay
 - Get to the end of a video
 - Press replay

### Loop
- Activate loop
- Get to the end of a video



## Visual reference


https://github.com/profusion/ios-enhanced-media-player/assets/53837251/5faa9489-21c5-42fe-bb9c-4ca9019a4183


