### PR TITLE
feat: rewind and foward buttons

### DIFF
--- a/EnhancedMediaPlayer.xcodeproj/project.pbxproj
+++ b/EnhancedMediaPlayer.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		AB4B39272A2F071C001390EA /* MediaPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4B39262A2F071C001390EA /* MediaPlayerView.swift */; };
 		E80F6F912A4B712800F90F7E /* SettingsPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80F6F902A4B712800F90F7E /* SettingsPreference.swift */; };
 		E885EB042A49FBA400541DC6 /* SettingsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E885EB032A49FBA400541DC6 /* SettingsMenu.swift */; };
+		EFD792352A4A01C4007C7652 /* MediaPlayerControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD792342A4A01C4007C7652 /* MediaPlayerControlsView.swift */; };
+		EFD792372A4A0721007C7652 /* MediaPlayerTappableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD792362A4A0721007C7652 /* MediaPlayerTappableView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +80,8 @@
 		AB4B39302A31079C001390EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E80F6F902A4B712800F90F7E /* SettingsPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPreference.swift; sourceTree = "<group>"; };
 		E885EB032A49FBA400541DC6 /* SettingsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenu.swift; sourceTree = "<group>"; };
+		EFD792342A4A01C4007C7652 /* MediaPlayerControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerControlsView.swift; sourceTree = "<group>"; };
+		EFD792362A4A0721007C7652 /* MediaPlayerTappableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerTappableView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +154,8 @@
 				AB26ED5B2A3A113A00A8242E /* MediaPlayer.swift */,
 				E885EB032A49FBA400541DC6 /* SettingsMenu.swift */,
 				E80F6F902A4B712800F90F7E /* SettingsPreference.swift */,
+				EFD792342A4A01C4007C7652 /* MediaPlayerControlsView.swift */,
+				EFD792362A4A0721007C7652 /* MediaPlayerTappableView.swift */,
 			);
 			path = EnhancedMediaPlayer;
 			sourceTree = "<group>";
@@ -335,6 +341,8 @@
 				E885EB042A49FBA400541DC6 /* SettingsMenu.swift in Sources */,
 				AB26ED612A408FE500A8242E /* View+readFrame.swift in Sources */,
 				E80F6F912A4B712800F90F7E /* SettingsPreference.swift in Sources */,
+				EFD792352A4A01C4007C7652 /* MediaPlayerControlsView.swift in Sources */,
+				EFD792372A4A0721007C7652 /* MediaPlayerTappableView.swift in Sources */,
 				AB4B39272A2F071C001390EA /* MediaPlayerView.swift in Sources */,
 				AB26ED582A32628700A8242E /* AVPlayerView.swift in Sources */,
 				AB26ED5C2A3A113A00A8242E /* MediaPlayer.swift in Sources */,

--- a/EnhancedMediaPlayer/MediaPlayer.swift
+++ b/EnhancedMediaPlayer/MediaPlayer.swift
@@ -4,13 +4,15 @@ import SwiftUI
 
 public struct MediaPlayer: UIViewControllerRepresentable {
     private let mediaURL: URL
+    private let seekFactor: TimeInterval
     
-    public init(url mediaURL: URL) {
+    public init(url mediaURL: URL, seekFactor: TimeInterval) {
         self.mediaURL = mediaURL
+        self.seekFactor = seekFactor
     }
     
     public func makeUIViewController(context: Context) -> MediaPlayerViewController {
-        let mediaPlayerController = MediaPlayerViewController(mediaURL: mediaURL)
+        let mediaPlayerController = MediaPlayerViewController(mediaURL: mediaURL, seekFactor: seekFactor)
         return mediaPlayerController
     }
 

--- a/EnhancedMediaPlayer/MediaPlayerControlsView.swift
+++ b/EnhancedMediaPlayer/MediaPlayerControlsView.swift
@@ -1,0 +1,194 @@
+// MediaPlayerControlsView.swift
+
+import SwiftUI
+
+struct MediaPlayerControlsView: View {
+    @ObservedObject var viewModel: ViewModel
+
+    @EnvironmentObject var preferences: SettingsPreferences
+
+    var body: some View {
+        renderOverlay()
+        renderActionButtons()
+            .padding(.horizontal, viewModel.screenWidth / Constants.paddingWidthDivider)
+    }
+
+    @ViewBuilder private func renderOverlay() -> some View {
+        Rectangle()
+            .fill(.black)
+            .opacity(Constants.overlayOpacity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder private func renderActionButtons() -> some View {
+        VStack(spacing: .zero) {
+            renderLoop()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            HStack(spacing: .zero) {
+                renderRewind()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                renderMainButtonState()
+                renderForward()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .frame(maxWidth: .infinity)
+            renderButton(control: .settings, size: Constants.settingsIconSize)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+        }
+    }
+
+    @ViewBuilder private func renderMainButtonState() -> some View {
+        switch viewModel.playerState {
+            case .playing: renderButton(control: .pause)
+            case .paused, .loading: renderButton(control: .play)
+            case .finished: renderButton(control: .replay)
+        }
+    }
+
+    @ViewBuilder private func renderLoop() -> some View {
+        renderButton(control: .loop, color: viewModel.inLoopEnabled ? .blue : .white)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    @ViewBuilder private func renderPlayPause() -> some View {
+        renderButton(control: viewModel.playerState == .playing ? .pause : .play)
+    }
+
+    @ViewBuilder private func renderReplay() -> some View {
+        renderButton(control: .replay)
+    }
+
+    @ViewBuilder private func renderRewind() -> some View {
+        renderTimePlaceholderWrapper {
+            renderButton(control: .rewind)
+        }
+    }
+
+    @ViewBuilder private func renderForward() -> some View {
+        renderTimePlaceholderWrapper {
+            renderButton(control: .forward)
+        }
+    }
+
+    @ViewBuilder private func renderButton(
+        control: Control,
+        color: Color = .white,
+        size: CGFloat = Constants.iconFontSize
+    ) -> some View {
+        control.systemImage
+            .font(.system(size: size))
+            .tint(color)
+            .wrapInButton {
+                handleControl(control)
+            }
+    }
+
+    @ViewBuilder private func renderTimePlaceholderWrapper<Content: View>(
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        ZStack {
+            content()
+            Text(viewModel.formattedSeekFactor)
+                .foregroundColor(.white)
+                .font(.system(size: Constants.timeFontSize))
+        }
+    }
+
+    private func handleControl(_ control: Control) {
+        // Not very ideal to do this, but as mentioned, we're abusing UIKit + SwiftUI...
+        guard control != .settings else {
+            preferences.isShowingSettingsMenu.toggle()
+            return
+        }
+
+        viewModel.onTapAction(control)
+    }
+}
+
+extension MediaPlayerControlsView {
+    class ViewModel: ObservableObject {
+        @Binding var screenWidth: CGFloat
+        @Binding var playerState: MediaPlayerView.PlayerState
+
+        let inLoopEnabled: Bool
+        let seekFactor: TimeInterval
+
+        let onTapAction: (Control) -> Void
+
+        var formattedSeekFactor: String {
+            seekFactor.truncatingRemainder(dividingBy: 1) == 0 ?
+                String(format: Constants.seekFactorFormat, seekFactor) :
+                String(format: Constants.seekFactorDecimalFormat, seekFactor)
+        }
+
+        init(
+            screenWidth: Binding<CGFloat>,
+            playerState: Binding<MediaPlayerView.PlayerState>,
+            seekFactor: TimeInterval,
+            inLoopEnabled: Bool,
+            onTapAction: @escaping ((Control) -> Void)
+        ) {
+            self._screenWidth = screenWidth
+            self._playerState = playerState
+            self.seekFactor = seekFactor
+            self.inLoopEnabled = inLoopEnabled
+            self.onTapAction = onTapAction
+        }
+    }
+}
+
+extension MediaPlayerControlsView {
+    enum Constants {
+        static let timeFontSize: CGFloat = 12
+        static let iconSize: CGSize = .init(width: 30, height: 30)
+        static let paddingWidthDivider: CGFloat = 6
+        static let overlayOpacity: CGFloat = 0.3
+        static let seekFactorFormat: String = "%.0fs"
+        static let seekFactorDecimalFormat: String = "%.1fs"
+        static let iconFontSize: CGFloat = 40
+        static let settingsIconSize: CGFloat = 20
+    }
+}
+
+extension MediaPlayerControlsView {
+    enum Control {
+        case play
+        case pause
+        case loop
+        case replay
+        case rewind
+        case forward
+        case settings
+
+        var systemImage: Image {
+            switch self {
+            case .play:
+                return Image(systemName: Constants.playIcon)
+            case .pause:
+                return Image(systemName: Constants.pauseIcon)
+            case .loop:
+                return Image(systemName: Constants.loopIcon)
+            case .replay:
+                return Image(systemName: Constants.replayIcon)
+            case .rewind:
+                return Image(systemName: Constants.rewindIcon)
+            case .forward:
+                return Image(systemName: Constants.forwardIcon)
+            case .settings:
+                return Image(systemName: Constants.settingsIcon)
+            }
+        }
+    }
+}
+
+extension MediaPlayerControlsView.Control {
+    enum Constants {
+        static let playIcon = "play.fill"
+        static let pauseIcon = "pause.fill"
+        static let loopIcon = "infinity"
+        static let replayIcon = "repeat"
+        static let forwardIcon = "goforward"
+        static let rewindIcon = "gobackward"
+        static let settingsIcon = "gearshape.fill"
+    }
+}

--- a/EnhancedMediaPlayer/MediaPlayerTappableView.swift
+++ b/EnhancedMediaPlayer/MediaPlayerTappableView.swift
@@ -1,0 +1,133 @@
+// MediaPlayerTappableView.swift
+
+import SwiftUI
+
+struct MediaPlayerTappableView: View {
+    @ObservedObject var viewModel: ViewModel
+
+    var body: some View {
+        HStack(spacing: .zero) {
+            renderTappableScreen(.backward)
+            renderControlsTriggerLayer()
+            renderTappableScreen(.forward)
+        }
+    }
+
+    @ViewBuilder func renderControlsTriggerLayer() -> some View {
+        Rectangle()
+            .foregroundColor(.clear)
+            .contentShape(Rectangle())
+            .frame(width: Constants.tappableControlScreenWidth)
+            .onTapGesture {
+                viewModel.onTapControlsTriggerArea()
+            }
+    }
+
+    @ViewBuilder private func renderTappableScreen(_ seek: Seek) -> some View {
+        ZStack {
+            renderSeekTapsDetector(seek)
+            renderSeekIcon(seek)
+        }
+    }
+
+    @ViewBuilder func renderSeekTapsDetector(_ seek: Seek) -> some View {
+        Rectangle()
+            .foregroundColor(.clear)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                viewModel.onTapSeekArea(seek)
+            }
+    }
+
+    @ViewBuilder func renderSeekIcon(_ seek: Seek) -> some View {
+        if viewModel.seekState.visibleSeek == seek {
+            seek.systemImage
+                .resizable()
+                .frame(width: Constants.iconSize.width, height: Constants.iconSize.height)
+                .foregroundColor(.white)
+        }
+    }
+}
+
+extension MediaPlayerTappableView {
+    class ViewModel: ObservableObject {
+        let seekState: SeekState
+        let isSeekByTapEnabled: Bool
+
+        let onTapSeekArea: (Seek) -> Void
+        let onTapControlsTriggerArea: () -> Void
+
+        var timer: Timer?
+
+        init(
+            seekState: SeekState,
+            isSeekByTapEnabled: Bool,
+            onTapSeekArea: @escaping (Seek) -> Void,
+            onTapControlsTriggerArea: @escaping () -> Void
+        ) {
+            self.seekState = seekState
+            self.isSeekByTapEnabled = isSeekByTapEnabled
+            self.onTapSeekArea = onTapSeekArea
+            self.onTapControlsTriggerArea = onTapControlsTriggerArea
+        }
+    }
+}
+
+extension MediaPlayerTappableView {
+    enum Constants {
+        static let iconSize: CGSize = .init(width: 30, height: 20)
+        static let doubleTap: Int = 2
+        static let singleTap: Int = 1
+        static let showSeekDelay: TimeInterval = 0.5
+        static let tappableControlScreenWidth: CGFloat = 120
+    }
+}
+
+extension MediaPlayerTappableView {
+    enum Seek {
+        case backward
+        case forward
+
+        var systemImage: Image {
+            switch self {
+            case .backward:
+                return Image(systemName: Constants.rewindIcon)
+            case .forward:
+                return Image(systemName: Constants.forwardIcon)
+            }
+        }
+    }
+}
+
+extension MediaPlayerTappableView {
+    enum SeekState {
+        case none
+        case ready(Seek)
+        case seeking(Seek)
+
+        var seek: Seek? {
+            switch self {
+            case .none:
+                return nil
+            case .ready(let seek), .seeking(let seek):
+                return seek
+            }
+        }
+
+        var visibleSeek: Seek? {
+            switch self {
+            case .none, .ready:
+                return nil
+            case .seeking(let seek):
+                return seek
+            }
+        }
+    }
+}
+
+extension MediaPlayerTappableView.Seek {
+    enum Constants {
+        static let rewindIcon = "backward.fill"
+        static let forwardIcon = "forward.fill"
+    }
+}

--- a/EnhancedMediaPlayer/MediaPlayerView.swift
+++ b/EnhancedMediaPlayer/MediaPlayerView.swift
@@ -5,10 +5,7 @@ import AVFoundation
 
 public struct MediaPlayerView: View {
     @ObservedObject var viewModel: MediaPlayerView.ViewModel
-
     @State private var screenWidth: CGFloat = .zero
-
-    @EnvironmentObject var preferences: SettingsPreferences
     
     public init(viewModel: MediaPlayerView.ViewModel) {
         self.viewModel = viewModel
@@ -17,140 +14,49 @@ public struct MediaPlayerView: View {
     public var body: some View {
         ZStack {
             AVPlayerView(player: viewModel.player, playerState: viewModel.playerState)
-            
-            if viewModel.isShowingActionButtons {
-                renderOverlay()
-                renderActionButtons()
-                    .padding(.horizontal, screenWidth / Constants.paddingWidthDivider)
+
+            MediaPlayerTappableView(viewModel: .init(
+                seekState: viewModel.seekState,
+                isSeekByTapEnabled: viewModel.isSeekByTapEnabled,
+                onTapSeekArea: { seek in viewModel.onTapSeekArea?(seek) },
+                onTapControlsTriggerArea: { viewModel.onTapControlsTriggerArea?() }
+            ))
+
+            if viewModel.areControlsVisible {
+                MediaPlayerControlsView(viewModel: .init(
+                    screenWidth: $screenWidth,
+                    playerState: $viewModel.playerState,
+                    seekFactor: viewModel.seekFactor,
+                    inLoopEnabled: viewModel.inLoopEnabled,
+                    onTapAction: { control in viewModel.onTapAction?(control) }
+                ))
             }
-        }
-        .onTapGesture {
-            viewModel.handleTapOnPlayer()
         }
         .readFrame { size in
             screenWidth = size.width
         }
     }
-    
-    @ViewBuilder private func renderOverlay() -> some View {
-        Rectangle()
-            .fill(.black)
-            .opacity(Constants.overlayOpacity)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    @ViewBuilder private func renderActionButtons() -> some View {
-        VStack(spacing: .zero) {
-            renderLoop()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            HStack(spacing: .zero) {
-                renderRewind()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                renderMainButtonState()
-                renderForward()
-                    .disabled(viewModel.playerState == .finished)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
-            }
-            .frame(maxWidth: .infinity)
-            renderButton(control: .settings, size: Constants.settingsIconSize)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
-        }
-    }
-
-    @ViewBuilder private func renderMainButtonState() -> some View {
-        switch viewModel.playerState {
-                case .playing: renderButton(control: .pause)
-                case .paused, .loading: renderButton(control: .play)
-                case .finished: renderButton(control: .replay)
-        }
-    }
-
-    @ViewBuilder private func renderLoop() -> some View {
-        renderButton(control: .loop, color: viewModel.inLoopEnabled ? .blue : .white)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-    }
-    
-    @ViewBuilder private func renderReplay() -> some View {
-        renderButton(control: .replay)
-    }
-    
-    @ViewBuilder private func renderRewind() -> some View {
-        renderTimeElapsedWrapper {
-            renderButton(control: .rewind)
-        }
-    }
-    
-    @ViewBuilder private func renderForward() -> some View {
-        renderTimeElapsedWrapper {
-            renderButton(control: .forward)
-        }
-    }
-    
-    @ViewBuilder private func renderButton(
-        control: Control,
-        color: Color = .white,
-        size: CGFloat = Constants.iconFontSize
-    ) -> some View {
-        control.systemImage
-            .font(.system(size: size))
-            .tint(color)
-            .wrapInButton {
-                handleControl(control)
-            }
-    }
-    
-    @ViewBuilder private func renderTimeElapsedWrapper<Content: View>(
-        @ViewBuilder content: @escaping () -> Content
-    ) -> some View {
-        ZStack {
-            content()
-            Text("10") // TODO: update with amount of rewind / forward
-                .foregroundColor(.white)
-                .font(.system(size: Constants.timeFontSize))
-                .frame(width: Constants.iconSize.width, height: Constants.iconSize.height)
-        }
-    }
-
-   private func handleControl(_ control: Control) {
-        // Not very ideal to do this, but as mentioned, we're abusing UIKit + SwiftUI...
-        guard control != .settings else {
-            preferences.isShowingSettingsMenu.toggle()
-            return
-        }
-
-       viewModel.onTapAction?(control)
-    }
 }
 
 extension MediaPlayerView {
     public class ViewModel: ObservableObject {
-        @Published var player: AVPlayer
+        @Published var isSeekByTapEnabled: Bool = true
         @Published var playerState: PlayerState = .loading
         @Published var inLoopEnabled: Bool = false
-        @Published var isShowingActionButtons = true
+        @Published var seekState: MediaPlayerTappableView.SeekState = .none
+        @Published var areControlsVisible: Bool = false
+        @Published var player: AVPlayer
 
-        var onTapAction: ((Control) -> Void)?
-        
-        init(player: AVPlayer) {
+        var onTapAction: ((MediaPlayerControlsView.Control) -> Void)?
+        var onTapSeekArea: ((MediaPlayerTappableView.Seek) -> Void)?
+        var onTapControlsTriggerArea: (() -> Void)?
+
+        let seekFactor: TimeInterval
+
+        init(player: AVPlayer, seekFactor: TimeInterval) {
             self.player = player
+            self.seekFactor = seekFactor
         }
-
-        func handleTapOnPlayer() {
-            withAnimation {
-                isShowingActionButtons.toggle()
-            }
-        }
-    }
-}
-
-extension MediaPlayerView {
-    enum Constants {
-        static let timeFontSize: CGFloat = 12
-        static let iconFontSize: CGFloat = 40
-        static let settingsIconSize: CGFloat = 20
-        static let iconSize: CGSize = .init(width: 30, height: 30)
-        static let paddingWidthDivider: CGFloat = 6
-        static let overlayOpacity: CGFloat = 0.3
     }
 }
 
@@ -163,55 +69,13 @@ extension MediaPlayerView {
     }
 }
 
-extension MediaPlayerView {
-    enum Control {
-        case play
-        case pause
-        case loop
-        case replay
-        case rewind
-        case forward
-        case settings
-        
-        var systemImage: Image {
-            switch self {
-            case .play:
-                return Image(systemName: Constants.playIcon)
-            case .pause:
-                return Image(systemName: Constants.pauseIcon)
-            case .loop:
-                return Image(systemName: Constants.loopIcon)
-            case .replay:
-                return Image(systemName: Constants.replayIcon)
-            case .rewind:
-                return Image(systemName: Constants.rewindIcon)
-            case .forward:
-                return Image(systemName: Constants.forwardIcon)
-            case .settings:
-                return Image(systemName: Constants.settingsIcon)
-            }
-        }
-    }
-}
-
-extension MediaPlayerView.Control {
-    enum Constants {
-        static let playIcon = "play.fill"
-        static let pauseIcon = "pause.fill"
-        static let loopIcon = "infinity"
-        static let replayIcon = "repeat"
-        static let forwardIcon = "goforward"
-        static let rewindIcon = "gobackward"
-        static let settingsIcon = "gearshape.fill"
-    }
-}
-
 #if DEBUG
 struct MediaPlayerView_Previews: PreviewProvider {
     static let testURL =  URL(string: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4")!
     static var previews: some View {
         MediaPlayerView(viewModel: .init(
-            player: .init(url: testURL)
+            player: .init(url: testURL),
+            seekFactor: 10
         ))
     }
 }

--- a/EnhancedMediaPlayerSample/ContentView.swift
+++ b/EnhancedMediaPlayerSample/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: .zero) {
-            MediaPlayer(url: URL(string: selected.url)!)
+            MediaPlayer(url: URL(string: selected.url)!, seekFactor: Constants.seekFactor)
                 .frame(height: 300)
 
             Picker(Constants.pickerLabel, selection: $selected) {
@@ -34,6 +34,7 @@ extension ContentView {
         static let streamVideo = "Stream Video"
         static let remoteVideo = "Remote Video"
         static let remoteMusic = "Remote Music"
+        static let seekFactor: TimeInterval = 10
     }
 }
 


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

- implement rewind and foward button functions
- implement rewind and foward double tap features
- implement consecutive taps after a double tap to
  rewind or forward the video too

## Related Issues

- Closes [#678](https://github.com/profusion/quickstart-ios-graphql/issues/678)

## Progress

- [x] Button functions
- [x] Double tap

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

### Buttons

1. Go to the audio
2. Click on forward button one or more times 
3. The audio must forward in 10 seconds
4. Do the same with the rewind button
5. The audio must rewind in 10 seconds

### Double Tap

1. Go to the audio
2. Double tap on one of the left or right side of the audio screen
3. The audio must forward/rewind in 10 seconds
4. Every tap that immediately follows the double tap should forward/rewind the video +10 seconds. For exemple 3 taps = 20 seconds, 4 taps = 30 seconds, ...

Obs.: In step 4, a tap must be given before 1 second is passed from the last tap


## Visual reference

<img width="250" alt="Screenshot of bug fix" src="https://github.com/profusion/ios-enhanced-media-player/assets/50057281/ceca3924-bbb1-42ac-8d99-57ccc287d6cf">

