### PR TITLE
 [Fix][#14] Demo app: when switching between medias the app crashes

### DIFF
--- a/Sources/EnhancedMediaPlayer/MediaPlayerView.swift
+++ b/Sources/EnhancedMediaPlayer/MediaPlayerView.swift
@@ -52,7 +52,7 @@ extension MediaPlayerView {
 
         var currentElapsedTimeBinding: Double {
             get {
-                videoCurrentTime
+                player.status == .readyToPlay ? videoCurrentTime : Constants.fallbackDuration
             }
             set {
                 player.seek(
@@ -64,7 +64,10 @@ extension MediaPlayerView {
         }
 
         var mediaTotalTime: Double {
-            player.currentItem?.duration.seconds ?? Constants.fallbackTotalDuration
+            guard let duration = player.currentItem?.duration.seconds, !duration.isNaN else {
+                return Constants.fallbackDuration
+            }
+            return duration
         }
 
         var onTapAction: ((MediaPlayerControlsView.Control) -> Void)?
@@ -92,7 +95,7 @@ extension MediaPlayerView {
 extension MediaPlayerView {
     enum Constants {
         static let defaultTimeScale: CMTimeScale = 30
-        static let fallbackTotalDuration: TimeInterval = 1
+        static let fallbackDuration: TimeInterval = .zero
     }
 }
 


### PR DESCRIPTION
## Description

Xcode reports a crash in Slider(value: $viewModel.currentElapsedTime, in: .zero...viewModel.mediaTotalTime) { because the viewModel.mediaTotalTime seems to be less or equal than .zero

## Solution

Just changed the default value of initial, minimum and maximum to `.zero` so it works when the media hasn't loaded yet

Tried to make the controls disabled but they already are disable, even if the UI doesn't change, so set it as disabled appeared weird. 

## Related Issues

- Closes #14

## How to test it

Open simulator and switch between different media.

## Visual reference

<img width="350" alt="Screenshot of bug fix" src="https://github.com/profusion/ios-enhanced-media-player/assets/49887488/e93b15d9-3968-4c9f-8921-023bcbc2f3aa">
