### PR TITLE
[16][feat] add loading indicator

### DIFF
--- a/Sources/EnhancedMediaPlayer/MediaPlayerView.swift
+++ b/Sources/EnhancedMediaPlayer/MediaPlayerView.swift
@@ -16,27 +16,35 @@ public struct MediaPlayerView: View {
         ZStack {
             AVPlayerView(player: viewModel.player, playerState: viewModel.playerState)
 
-            MediaPlayerTappableView(viewModel: .init(
-                seekState: viewModel.seekState,
-                isSeekByTapEnabled: viewModel.isSeekByTapEnabled,
-                onTapSeekArea: { seek in viewModel.onTapSeekArea?(seek) },
-                onTapControlsTriggerArea: { viewModel.onTapControlsTriggerArea?() }
-            ))
-
-            if viewModel.areControlsVisible {
-                MediaPlayerControlsView(viewModel: .init(
-                    screenWidth: $screenWidth,
-                    playerState: $viewModel.playerState,
-                    seekFactor: viewModel.seekFactor,
-                    inLoopEnabled: viewModel.inLoopEnabled,
-                    currentElapsedTime: $viewModel.currentElapsedTimeBinding,
-                    mediaTotalTime: viewModel.mediaTotalTime,
-                    onTapAction: { control in viewModel.onTapAction?(control) }
-                ))
+            if viewModel.player.status != .readyToPlay {
+                ProgressView()
+            } else {
+                renderActivePlayerViews()
             }
         }
         .readFrame { size in
             screenWidth = size.width
+        }
+    }
+    
+    @ViewBuilder private func renderActivePlayerViews() -> some View {
+        MediaPlayerTappableView(viewModel: .init(
+            seekState: viewModel.seekState,
+            isSeekByTapEnabled: viewModel.isSeekByTapEnabled,
+            onTapSeekArea: { seek in viewModel.onTapSeekArea?(seek) },
+            onTapControlsTriggerArea: { viewModel.onTapControlsTriggerArea?() }
+        ))
+
+        if viewModel.areControlsVisible {
+            MediaPlayerControlsView(viewModel: .init(
+                screenWidth: $screenWidth,
+                playerState: $viewModel.playerState,
+                seekFactor: viewModel.seekFactor,
+                inLoopEnabled: viewModel.inLoopEnabled,
+                currentElapsedTime: $viewModel.currentElapsedTimeBinding,
+                mediaTotalTime: viewModel.mediaTotalTime,
+                onTapAction: { control in viewModel.onTapAction?(control) }
+            ))
         }
     }
 }


### PR DESCRIPTION
## Description

Media needs to be fetched in order to be reproduced locally and to indicate this state of download/buffering we need a visual loading indicator


## Related Issues

- Closes #16

## Discussion

In the specification is said:
- Loading should stop after a buffer size has been downloaded
- Buffer size should be customizable (Nice-to-have) 

I made some tests with https://developer.apple.com/documentation/avfoundation/avplayeritem/1643630-preferredforwardbufferduration but couldn't find a way to test it appropriately 

<!-- Describe how the reviewers can test your feature. -->

## Visual reference

Screenshots

<img width="350" alt="Screenshot of bug fix" src="https://github.com/profusion/ios-enhanced-media-player/assets/49887488/76a32dd6-5dc6-4edc-b357-c7415cfb5406">

Demo
<img width="350" alt="Screen Recording" src="https://github.com/profusion/ios-enhanced-media-player/assets/49887488/4fb7f45e-aac6-4d38-967e-5f161d1785e9">

